### PR TITLE
Fixed fuseki config

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -2,6 +2,47 @@
 
 This `tests/` part of this repo contains Docker and Python scripts to run a Fuseki instance to test scenario queries against the catalogue data.
 
-Fuseki can be run from the Taskfile within `fuseki/`.
+Fuseki can be run from the Taskfile within `fuseki/` by runnign `task fup`.
+
+Once the server is up, datasets can be created, such as the test dataset in `fuseki/data/dataset-config.ttl`.
+
+```
+kurra db create http://localhost:3030 --config ./data/dataset-config.ttl
+```
+
+You'll see a warning in the docker logs of the `fuseki` service:
+
+```
+WARN  GeoAssembler    :: Dataset empty. Spatial Index not constructed. Server will require restarting after adding data and any updates to build Spatial Index.
+```
+
+We can add some data and restart the server:
+```
+kurra db upload ../../resources/datasets/nvis.ttl http://localhost:3030/eiatest-catalogue
+
+task frs
+```
+
+Now you should see that the spatial index was created:
+
+```
+SpatialIndex    :: Saving Spatial Index - Completed: /fuseki/databases/eiatest-catalogue/spatial.index
+```
+
+Which means the following query should now work:
+
+```
+PREFIX geo: <http://www.opengis.net/ont/geosparql#>
+PREFIX geof: <http://www.opengis.net/def/function/geosparql/>
+
+SELECT DISTINCT ?dataset
+WHERE {
+  BIND("POLYGON((112.76 -10.23, 155.48 -10.23, 155.48 -44.28, 112.76 -44.28, 112.76 -10.23))"^^geo:wktLiteral AS ?polygon) #Bounding box of Australia
+  ?dataset geo:boundingBox / geo:asWKT ?boundingbox .
+  FILTER(geof:sfWithin(?boundingbox, ?polygon))
+}
+# returns
+# 1<https://linked.data.gov.au/dataset/eiatest/nvis>
+```
 
 Each scenario is described within subfolder of the `scenario/` folder.

--- a/tests/fuseki/Taskfile.yml
+++ b/tests/fuseki/Taskfile.yml
@@ -6,5 +6,8 @@ tasks:
   fup:
     cmd: docker compose up -d
 
+  frs:
+    cmd: docker compose restart fuseki
+
   fdown:
     cmd: docker compose down

--- a/tests/fuseki/data/.gitignore
+++ b/tests/fuseki/data/.gitignore
@@ -1,0 +1,7 @@
+backups/*
+configuration/*
+databases/*
+logs/*
+system/*
+system_files/*
+templates/*

--- a/tests/fuseki/data/config.ttl
+++ b/tests/fuseki/data/config.ttl
@@ -1,75 +1,32 @@
-@prefix :       <http://base/#> .
-@prefix fuseki: <http://jena.apache.org/fuseki#> .
-@prefix ja:     <http://jena.hpl.hp.com/2005/11/Assembler#> .
-@prefix rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix rdfs:   <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix tdb2:   <http://jena.apache.org/2016/tdb#> .
-@prefix geosparql: <http://jena.apache.org/geosparql#> .
+PREFIX :          <http://base/#>
+PREFIX bibo:      <http://purl.org/ontology/bibo/>
+PREFIX dc:        <http://purl.org/dc/elements/1.1/>
+PREFIX dcterms:   <http://purl.org/dc/terms/>
+PREFIX ex:        <http://example.org/>
+PREFIX fuseki:    <http://jena.apache.org/fuseki#>
+PREFIX geosparql: <http://jena.apache.org/geosparql#>
+PREFIX ja:        <http://jena.hpl.hp.com/2005/11/Assembler#>
+PREFIX rdf:       <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs:      <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX schema:    <https://schema.org/>
+PREFIX skos:      <http://www.w3.org/2004/02/skos/core#>
+PREFIX tdb2:      <http://jena.apache.org/2016/tdb#>
+PREFIX text:      <http://jena.apache.org/text#>
 
-tdb2:GraphTDB  rdfs:subClassOf  ja:Model .
+[] rdf:type fuseki:Server ;
+   # Example::
+   # Server-wide query timeout.
+   #
+   # Timeout - server-wide default: milliseconds.
+   # Format 1: "1000" -- 1 second timeout
+   # Format 2: "10000,60000" -- 10s timeout to first result,
+   #                            then 60s timeout for the rest of query.
+   #
+   # See javadoc for ARQ.queryTimeout for details.
+   # This can also be set on a per dataset basis in the dataset assembler.
+   #
+   ja:context [ ja:cxtName "arq:queryTimeout" ;  ja:cxtValue "30000" ] ;
 
-ja:ModelRDFS  rdfs:subClassOf  ja:Model .
-
-ja:RDFDatasetSink  rdfs:subClassOf  ja:RDFDataset .
-
-<http://jena.hpl.hp.com/2008/tdb#DatasetTDB>
-        rdfs:subClassOf  ja:RDFDataset .
-
-tdb2:GraphTDB2  rdfs:subClassOf  ja:Model .
-
-<http://jena.apache.org/text#TextDataset>
-        rdfs:subClassOf  ja:RDFDataset .
-
-ja:RDFDatasetZero  rdfs:subClassOf  ja:RDFDataset .
-
-:service_tdb_all  rdf:type            fuseki:Service ;
-        rdfs:label                    "TDB2 prez" ;
-        fuseki:dataset                :tdb_dataset_readwrite ;
-        fuseki:name                   "prez" ;
-        fuseki:serviceQuery           "query" , "" , "sparql" ;
-        fuseki:serviceReadGraphStore  "get" ;
-        fuseki:serviceReadWriteGraphStore "data" ;
-        fuseki:serviceUpdate          "" , "update" .
-
-ja:ViewGraph  rdfs:subClassOf  ja:Model .
-
-ja:GraphRDFS  rdfs:subClassOf  ja:Model .
-
-tdb2:DatasetTDB  rdfs:subClassOf  ja:RDFDataset .
-
-<http://jena.hpl.hp.com/2008/tdb#GraphTDB>
-        rdfs:subClassOf  ja:Model .
-
-ja:DatasetTxnMem  rdfs:subClassOf  ja:RDFDataset .
-
-tdb2:DatasetTDB2  rdfs:subClassOf  ja:RDFDataset .
-
-ja:RDFDatasetOne  rdfs:subClassOf  ja:RDFDataset .
-
-ja:MemoryDataset  rdfs:subClassOf  ja:RDFDataset .
-
-<#prez> rdf:type geosparql:geosparqlDataset ;
-  geosparql:spatialIndexFile "/fuseki/databases/prez/spatial.index";
-
-  # some GeoSPARQL settings
-  geosparql:inference            false ;
-  geosparql:queryRewrite         false ;
-  geosparql:indexEnabled         true ;
-  geosparql:applyDefaultGeometry false ;
-
-  # 3 item lists: [Geometry Literal, Geometry Transform, Query Rewrite]
-  geosparql:indexSizes           "-1,-1,-1" ;       # Default - unlimited.
-  geosparql:indexExpires         "5000,5000,5000" ; # Default - time in milliseconds.
-
-  geosparql:dataset :tdb_dataset_readwrite ;
-  .
-
-:tdb_dataset_readwrite
-        rdf:type       tdb2:DatasetTDB2 ;
-        tdb2:unionDefaultGraph true ;
-        tdb2:location  "/fuseki/databases/prez" .
-
-ja:DatasetRDFS  rdfs:subClassOf  ja:RDFDataset .
-
-<http://jena.apache.org/geosparql#geosparqlDataset>
-        rdfs:subClassOf  ja:RDFDataset .
+   # Add any custom classes you want to load.
+   # Must have a "public static void init()" method.
+.

--- a/tests/fuseki/data/dataset-config.ttl
+++ b/tests/fuseki/data/dataset-config.ttl
@@ -1,0 +1,98 @@
+@prefix :       <http://base/#> .
+@prefix fuseki: <http://jena.apache.org/fuseki#> .
+@prefix ja:     <http://jena.hpl.hp.com/2005/11/Assembler#> .
+@prefix rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:   <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix tdb2:   <http://jena.apache.org/2016/tdb#> .
+@prefix geosparql: <http://jena.apache.org/geosparql#> .
+@prefix text: <http://jena.apache.org/text#> .
+
+ja:DatasetRDFS  rdfs:subClassOf  ja:RDFDataset .
+
+geosparql:geosparqlDataset  rdfs:subClassOf  ja:RDFDataset .
+
+tdb2:GraphTDB  rdfs:subClassOf  ja:Model .
+
+ja:ModelRDFS  rdfs:subClassOf  ja:Model .
+
+ja:RDFDatasetSink  rdfs:subClassOf  ja:RDFDataset .
+
+<http://jena.hpl.hp.com/2008/tdb#DatasetTDB>
+        rdfs:subClassOf  ja:RDFDataset .
+
+tdb2:GraphTDB2  rdfs:subClassOf  ja:Model .
+
+text:TextDataset  rdfs:subClassOf  ja:RDFDataset .
+
+ja:RDFDatasetZero  rdfs:subClassOf  ja:RDFDataset .
+
+ja:ViewGraph  rdfs:subClassOf  ja:Model .
+
+ja:GraphRDFS  rdfs:subClassOf  ja:Model .
+
+tdb2:DatasetTDB  rdfs:subClassOf  ja:RDFDataset .
+
+<http://jena.hpl.hp.com/2008/tdb#GraphTDB>
+        rdfs:subClassOf  ja:Model .
+
+ja:DatasetTxnMem  rdfs:subClassOf  ja:RDFDataset .
+
+tdb2:DatasetTDB2  rdfs:subClassOf  ja:RDFDataset .
+
+ja:RDFDatasetOne  rdfs:subClassOf  ja:RDFDataset .
+
+ja:MemoryDataset  rdfs:subClassOf  ja:RDFDataset .
+
+:service_test  rdf:type            fuseki:Service ;
+        rdfs:label                    "EIA Test Catalogue" ;
+        fuseki:dataset                :test_text_dataset ;
+        fuseki:name                   "eiatest-catalogue" ;
+        fuseki:serviceQuery           "query" , "" , "sparql" ;
+        fuseki:serviceReadGraphStore  "get" ;
+        fuseki:serviceReadWriteGraphStore "data" ;
+        fuseki:serviceUpdate          "" , "update" .
+
+:test_spatial_dataset rdf:type geosparql:geosparqlDataset ;
+  geosparql:spatialIndexFile "/fuseki/databases/eiatest-catalogue/spatial.index";
+
+  # some GeoSPARQL settings. See https://jena.apache.org/documentation/geosparql/geosparql-fuseki.html
+  geosparql:inference            true ; # GeoSPARQL RDFS schema and inferencing (adds additional statements to the dataset)
+  geosparql:queryRewrite         true ; # Simplifies queries, relies on applyDefaultGeometry
+  geosparql:applyDefaultGeometry true ; # Makes the dataset less dependent on one serialization. Adds additional geo:hasSerialization statements to the dataset
+  geosparql:indexEnabled         true ; # Enable caching of re-usable data to improve query performance
+  geosparql:validateGeometryLiterals true ; # Logs warnings when adding invalid geometry
+
+  # 3 item lists: [Geometry Literal, Geometry Transform, Query Rewrite]
+  geosparql:indexSizes           "-1,-1,-1" ;       # Default - unlimited.
+  geosparql:indexExpires         "5000,5000,5000" ; # Default - time in milliseconds.
+
+  geosparql:dataset :test_geosparql_dataset .
+
+:test_geosparql_dataset
+        rdf:type       tdb2:DatasetTDB2 ;
+        tdb2:unionDefaultGraph true ;
+        tdb2:location  "/fuseki/databases/eiatest-catalogue" .
+
+:test_text_dataset rdf:type     text:TextDataset ;
+        text:dataset   :test_spatial_dataset ;
+        text:index     <#indexLucene> .
+
+<#indexLucene> a text:TextIndexLucene ;
+    text:directory <file:/fuseki/databases/eiatest-catalogue/text_index> ;
+    text:entityMap <#entMap> ;
+    text:storeValues true ;
+    text:analyzer [ a text:StandardAnalyzer ] ;
+    text:queryAnalyzer [ a text:StandardAnalyzer ] ;
+    text:queryParser text:QueryParser ;
+    text:multilingualSupport true .
+
+<#entMap> a text:EntityMap ;
+    text:defaultField     "label" ;
+    text:entityField      "uri" ;
+    text:uidField         "uid" ;
+    text:langField        "lang" ;
+    text:graphField       "graph" ;
+    text:map (
+        [ text:field "label" ;
+          text:predicate rdfs:label ]
+    ) .

--- a/tests/fuseki/docker-compose.yml
+++ b/tests/fuseki/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   fuseki:
-    image: ghcr.io/kurrawong/fuseki:5.2.0-0
+    image: ghcr.io/kurrawong/fuseki:5.2.0-2
     ports:
       - 3030:3030
     volumes:


### PR DESCRIPTION

Fuseki can be run from the Taskfile within `fuseki/` by runnign `task fup`.

Once the server is up, datasets can be created, such as the test dataset in `fuseki/data/dataset-config.ttl`.

```
kurra db create http://localhost:3030 --config ./data/dataset-config.ttl
```

You'll see a warning in the docker logs of the `fuseki` service:

```
WARN  GeoAssembler    :: Dataset empty. Spatial Index not constructed. Server will require restarting after adding data and any updates to build Spatial Index.
```

We can add some data and restart the server:
```
kurra db upload ../../resources/datasets/nvis.ttl http://localhost:3030/eiatest-catalogue

task frs
```

Now you should see that the spatial index was created:

```
SpatialIndex    :: Saving Spatial Index - Completed: /fuseki/databases/eiatest-catalogue/spatial.index
```

Which means the following query should now work:

```
PREFIX geo: <http://www.opengis.net/ont/geosparql#>
PREFIX geof: <http://www.opengis.net/def/function/geosparql/>

SELECT DISTINCT ?dataset
WHERE {
  BIND("POLYGON((112.76 -10.23, 155.48 -10.23, 155.48 -44.28, 112.76 -44.28, 112.76 -10.23))"^^geo:wktLiteral AS ?polygon) #Bounding box of Australia
  ?dataset geo:boundingBox / geo:asWKT ?boundingbox .
  FILTER(geof:sfWithin(?boundingbox, ?polygon))
}
# returns
# 1<https://linked.data.gov.au/dataset/eiatest/nvis>
```
